### PR TITLE
as opposed to working around "The message port closed before a repons…

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,7 +12,7 @@
    "manifest_version": 2,
    "name": "recrun",
    "permissions": [ "tabs" ],
-   "version": "3.1.6",
+   "version": "3.1.8",
    "browser_action": {
       "default_icon": "icons/icon38.png"
    },

--- a/src/content.js
+++ b/src/content.js
@@ -208,8 +208,12 @@ var receiveMessage = function(event) {
 //the following is for receiving a message from an iframe, not the extension background
 window.addEventListener("message", receiveMessage, false);
 
-chrome.runtime.onMessage.addListener(function(request) {
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
     var method = request.method;
+    // this prevents chrome.runtime.lastError from firing for no response
+    // see https://bugs.chromium.org/p/chromium/issues/detail?id=586155
+    // alternatively, could return true for each return from this function
+    sendResponse(true);
     
     if (method === "recrun") {        
         var _shown = shown(); // could have a toggle flag for this


### PR DESCRIPTION
…e was received.", sending a response avoids that message
