### PR TITLE
Switch to Manifest V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/archive.zip
-/.idea
-/.project
-/.settings
 .DS_Store
+Thumbs.db
+/archive_chrome.zip
+/archive_firefox.zip
+/manifest.json

--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ the *recrun* icon.
 
 ![Screenshot](screenshots/screenshotWithArrow.png)
 
+Development
+-----------
+
+A different `manifest.json` is used for Chrome and Firefox. For development, create a symbolic link
+`manifest.json` that points to either `manifest_chrome.json` or `manifest_firefox.json`, depending
+on the environment.
+
+To generate zip archives, run `zip.sh`.
+
 License
 -------
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,13 +1,13 @@
 {
-  "permissions": ["activeTab", "storage"],
+  "permissions": ["activeTab", "scripting", "storage"],
   "options_ui": {
     "page": "src/options.html"
   },
   "description": "Retain essential content, remove unwanted noise.",
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "recrun",
   "version": "3.4.4",
-  "browser_action": {
+  "action": {
     "default_icon": "icons/icon38.png"
   },
   "icons": {
@@ -16,15 +16,18 @@
     "128": "icons/icon128.png"
   },
   "background": {
-    "scripts": [
-      "src/background.js"
-    ]
+    "service_worker": "src/background.js"
   },
   "web_accessible_resources": [
-    "src/loader.gif",
-    "src/style.css",
-    "src/options.html",
-    "src/iframe.html",
-    "src/content.html"
+    {
+      "resources": [
+        "src/loader.gif",
+        "src/style.css",
+        "src/options.html",
+        "src/iframe.html",
+        "src/content.html"
+      ],
+      "matches": ["<all_urls>"]
+    }
   ]
 }

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -17,7 +17,7 @@
     "page": "src/options.html"
   },
   "permissions": ["activeTab", "scripting", "storage"],
-  "version": "3.4.5",
+  "version": "3.5.0",
   "web_accessible_resources": [
     {
       "matches": ["<all_urls>"],

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -1,33 +1,33 @@
 {
-  "permissions": ["activeTab", "scripting", "storage"],
-  "options_ui": {
-    "page": "src/options.html"
-  },
-  "description": "Retain essential content, remove unwanted noise.",
-  "manifest_version": 3,
-  "name": "recrun",
-  "version": "3.4.5",
   "action": {
     "default_icon": "icons/icon38.png"
   },
+  "background": {
+    "service_worker": "src/background.js"
+  },
+  "description": "Retain essential content, remove unwanted noise.",
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",
     "128": "icons/icon128.png"
   },
-  "background": {
-    "service_worker": "src/background.js"
+  "manifest_version": 3,
+  "name": "recrun",
+  "options_ui": {
+    "page": "src/options.html"
   },
+  "permissions": ["activeTab", "scripting", "storage"],
+  "version": "3.4.5",
   "web_accessible_resources": [
     {
+      "matches": ["<all_urls>"],
       "resources": [
         "src/loader.gif",
         "src/style.css",
         "src/options.html",
         "src/iframe.html",
         "src/content.html"
-      ],
-      "matches": ["<all_urls>"]
+      ]
     }
   ]
 }

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,0 +1,38 @@
+{
+  "action": {
+    "default_icon": "icons/icon38.png"
+  },
+  "background": {
+    "scripts": ["src/background.js"]
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "{ae016343-4621-41f9-824f-efbe9afa931d}"
+    }
+  },
+  "description": "Retain essential content, remove unwanted noise.",
+  "icons": {
+    "16": "icons/icon16.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "manifest_version": 3,
+  "name": "recrun",
+  "options_ui": {
+    "page": "src/options.html"
+  },
+  "permissions": ["activeTab", "scripting", "storage"],
+  "version": "3.4.5",
+  "web_accessible_resources": [
+    {
+      "matches": ["<all_urls>"],
+      "resources": [
+        "src/loader.gif",
+        "src/style.css",
+        "src/options.html",
+        "src/iframe.html",
+        "src/content.html"
+      ]
+    }
+  ]
+}

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -22,7 +22,7 @@
     "page": "src/options.html"
   },
   "permissions": ["activeTab", "scripting", "storage"],
-  "version": "3.4.5",
+  "version": "3.5.0",
   "web_accessible_resources": [
     {
       "matches": ["<all_urls>"],

--- a/src/background.js
+++ b/src/background.js
@@ -1,17 +1,5 @@
-// WARN: For functions that are called from the options page, proper scope is
-// necessary (e.g., using a function declaration beginning with a 'function',
-// or using a function expression beginning with 'var', but not a function
-// expression beginning with 'let' or 'const').
-
-const IS_FIREFOX = chrome.runtime.getURL('').startsWith('moz-extension://');
-
 // This is called from options.js (see scope warning above).
-function getVersion() {
-    return chrome.runtime.getManifest().version;
-}
-
-// This is called from options.js (see scope warning above).
-function defaultOptions() {
+const defaultOptions = function() {
     const options = Object.create(null);
     options['token'] = '';
     options['media'] = true;
@@ -19,10 +7,10 @@ function defaultOptions() {
     options['diffbotHtml'] = false;
     options['useDiffbot'] = false;
     return options;
-}
+};
 
 // Set missing options using defaults.
-const normalizeOptions = function() {
+(function() {
     chrome.storage.local.get({options: {}}, function(result) {
         let opts = result.options;
         const defaults = defaultOptions();
@@ -35,48 +23,9 @@ const normalizeOptions = function() {
         }
         chrome.storage.local.set({options: opts});
     });
-};
-
-(function() {
-    if ('options' in localStorage) {
-        // If there are localStorage options, transfer them to chrome.storage.local.
-        // TODO: This can eventually be removed, at which point the normalizeOptions()
-        // function should be deleted, and its code moved here.
-        let opts = localStorage['options'];
-        localStorage.clear();
-        chrome.storage.local.set({options: JSON.parse(opts)}, function() {
-            normalizeOptions();
-        });
-    } else {
-        normalizeOptions();
-    }
 })();
 
-const inject = function(callback=function() {}, scripts=[]) {
-    let fn = callback;
-    for (let i = scripts.length - 1; i >= 0; --i) {
-        let script = scripts[i];
-        let fn_ = fn;
-        fn = function() {
-            chrome.tabs.executeScript({
-                file: script
-            }, fn_);
-        }
-    }
-    fn();
-};
-
-chrome.browserAction.onClicked.addListener(function(tab) {
-    const showError = function() {
-        const errorMessage = 'recrun couldn\'t run on this page.';
-        // alert() doesn't work from Firefox background pages. A try/catch block is
-        // not sufficient to prevent the "Browser Console" window that pops up with
-        // the following message when using alert():
-        // > "The Web Console logging API (console.log, console.info, console.warn,
-        // > console.error) has been disabled by a script on this page."
-        if (!IS_FIREFOX)
-            alert(errorMessage);
-    };
+chrome.action.onClicked.addListener(function(tab) {
     const recrun = function() {
         chrome.tabs.sendMessage(
             tab.id,
@@ -91,28 +40,38 @@ chrome.browserAction.onClicked.addListener(function(tab) {
     // First check if the current page is supported by trying to inject no-op code.
     // (e.g., https://chrome.google.com/webstore, https://addons.mozilla.org/en-US/firefox/,
     // chrome://extensions/, and other pages do not support extensions).
-    chrome.tabs.executeScript(
-        {code: '(function(){})();'},
-        function() {
-            if (chrome.runtime.lastError) {
-                showError();
-                return;
-            }
-            chrome.tabs.sendMessage(
-                tab.id,
-                {method: 'ping', data: {url: tab.url}},
-                {},
-                function(resp) {
-                    let scripts = [];
-                    // Always inject readabilitySAX, as it seems to get clobbered in some cases
-                    // (e.g., when toggling Firefox's reader view).
-                    scripts.push('src/lib/readabilitySAX/readabilitySAX.js');
-                    // Inject content script if it hasn't been injected yet.
-                    // On Firefox, in some cases just checking for lastError is not sufficient.
-                    if (chrome.runtime.lastError || !resp || !resp.success) {
-                        scripts.push('src/content.js');
-                    }
-                    inject(recrun, scripts);
+    chrome.scripting.executeScript({
+        target: {tabId: tab.id},
+        func: () => {(function(){})();}
+    }, (results) => {
+        if (chrome.runtime.lastError) {
+            // Earlier versions showed an error message here using alert():
+            //   recrun couldn't run on this page.
+            // This was avoided on Firefox, since it led to an error popup.
+            // However, with manifest v3's service workers, showing a message with alert()
+            // is not possible.
+            return;
+        }
+        chrome.tabs.sendMessage(
+            tab.id,
+            {method: 'ping', data: {url: tab.url}},
+            {},
+            function(resp) {
+                const scripts = [];
+                // Always inject readabilitySAX, as it seems to get clobbered in some cases
+                // (e.g., when toggling Firefox's reader view).
+                scripts.push('src/lib/readabilitySAX/readabilitySAX.js');
+                // Inject content script if it hasn't been injected yet.
+                // On Firefox, in some cases just checking for lastError is not sufficient.
+                if (chrome.runtime.lastError || !resp || !resp.success) {
+                    scripts.push('src/content.js');
+                }
+                chrome.scripting.executeScript({
+                    target: {tabId: tab.id},
+                    files: scripts
+                }, () => {
+                    recrun();
                 });
-        });
+            });
+    });
 });

--- a/src/background.js
+++ b/src/background.js
@@ -75,3 +75,10 @@ chrome.action.onClicked.addListener(function(tab) {
             });
     });
 });
+
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    const method = request.method;
+    if (method === 'getDefaultOptions') {
+        sendResponse(defaultOptions());
+    }
+});

--- a/src/options.js
+++ b/src/options.js
@@ -119,4 +119,4 @@ document.addEventListener('DOMContentLoaded', function() {
 })();
 
 // version
-document.getElementById('version').innerText = backgroundPage.getVersion();
+document.getElementById('version').innerText = chrome.runtime.getManifest().version;

--- a/src/options.js
+++ b/src/options.js
@@ -11,8 +11,6 @@ const statusMessage = function(message, time) {
     }, time);
 };
 
-const backgroundPage = chrome.extension.getBackgroundPage();
-
 const useDiffbot = document.getElementById('useDiffbot-checkbox');
 
 // enable Diffbot settings when 'Use Diffbot' is selected
@@ -82,9 +80,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // Load default options.
         document.getElementById('defaults').addEventListener('click', function() {
-            const defaults = backgroundPage.defaultOptions();
-            loadOptions(defaults);
-            statusMessage('Defaults Loaded', 1200);
+            chrome.runtime.sendMessage({method: 'getDefaultOptions'}, (response) => {
+                loadOptions(response);
+                statusMessage('Defaults Loaded', 1200);
+            });
         });
 
         document.getElementById('revert').addEventListener('click', function() {

--- a/zip.sh
+++ b/zip.sh
@@ -1,21 +1,31 @@
 #!/usr/bin/env bash
 
-# run this from the package directory
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${scriptdir}"
 
-# easier to see args in an array than a string
-ARGS=()
-ARGS+=("icons/")
-ARGS+=("src/")
-ARGS+=("manifest.json")
+gen_archive() {
+  browser="${1}"
 
-# exclude
-ARGS+=("-x")
-ARGS+=("*.DS_Store")
+  # easier to see args in an array than a string
+  args=()
+  args+=("icons/")
+  args+=("src/")
+  args+=("manifest_${browser}.json")
 
-archive="archive.zip"
+  # exclude
+  args+=("-x")
+  args+=("*.DS_Store")
+  args+=("*Thumbs.db")
 
-if [ -f "${archive}" ]; then
-	rm "${archive}"
-fi
+  archive="archive_${browser}.zip"
 
-zip -r "${archive}" "${ARGS[@]}"
+  if [ -f "${archive}" ]; then
+    rm "${archive}"
+  fi
+
+  zip -r "${archive}" "${args[@]}"
+  printf "@ manifest_${browser}.json\n@=manifest.json\n" | zipnote -w "${archive}"
+}
+
+gen_archive chrome
+gen_archive firefox


### PR DESCRIPTION
This PR updates the extension to use Manifest V3.

Starting in January 2023, "the Chrome browser will no longer run Manifest V2 extensions." ([source](https://developer.chrome.com/blog/mv2-transition/))

Firefox does not currently support Manifest V3, but it is scheduled to be available soon: "we are hoping to complete enough work on this project to support developer testing in Q4 2021 and start accepting v3 submissions in early 2022." ([source](https://blog.mozilla.org/addons/2021/05/27/manifest-v3-update/))